### PR TITLE
Fix stale cue text showing from previous session

### DIFF
--- a/index.html
+++ b/index.html
@@ -2480,8 +2480,11 @@ function startSet(){
     document.getElementById('ex-pause-btn').style.display='flex';
     document.getElementById('pause-icon').className='fas fa-pause text-4xl text-slate-300';
     setFocusedMode(true);
-    // Show first cue immediately
-    const firstCue=[...ex.cues].sort((a,b)=>b.time-a.time).find(c=>c.time>=ex.duration);
+    // Show first cue immediately — fall back to the highest-time cue if none
+    // covers the full (difficulty-adjusted) duration, and always clear any
+    // stale cue text left over from a previous exercise or session.
+    const sortedCues=[...ex.cues].sort((a,b)=>b.time-a.time);
+    const firstCue=sortedCues.find(c=>c.time>=ex.duration)||sortedCues[0];
     if(firstCue) updateActiveCue(firstCue.text.replace('{DIR}',DIRECTIONALS[session.directionalIndex]));
     session.timer=createTimer(ex.duration,rem=>{
         document.getElementById('ex-timer').innerText=fmtDuration(rem);


### PR DESCRIPTION
## What this fixes

When a user ran a **length session** before starting a **girth session**, the cue display element retained text from the Directional Pulls exercise (e.g. *"Pull OUT at firm 60% force"*). This stale text would show during the Uli — Manual Clamp set because:

1. The cue element was never cleared when a new exercise loaded
2. On Intermediate/Advanced difficulty, Uli's duration (45s/60s) exceeds all its cue timestamps (max 30s), so no first cue fired to replace the stale text

## Fix

In `startSet`, fall back to the highest-time cue when none covers the full difficulty-adjusted duration. This ensures the cue panel is always populated with correct content when a set begins — and clears any leftover text from a previous exercise or session.

**Bonus:** Intermediate and Advanced Uli sessions now correctly show the first cue immediately on start (previously the cue panel was silent for the opening portion of the set).