### PR TITLE
UI improvements: spinners, onboarding, modals, dashboard polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,14 +106,14 @@
         #password-reset-modal{position:fixed;inset:0;background:var(--bg-deep);z-index:99999;display:none;align-items:center;justify-content:center;padding:2rem}
         #password-reset-modal.show{display:flex}
         /* Soreness warning modal */
-        #soreness-warning-modal{position:fixed;inset:0;background:rgba(2,6,23,.95);z-index:99995;backdrop-filter:blur(20px);display:none;align-items:center;justify-content:center;padding:2rem}
+        #soreness-warning-modal{position:fixed;inset:0;background:rgba(2,6,23,.97);z-index:99995;backdrop-filter:blur(20px);display:none;align-items:center;justify-content:center;padding:2rem}
         #soreness-warning-modal.show{display:flex}
         /* Blackout day */
         .blackout-banner{background:linear-gradient(135deg,rgba(99,102,241,.1) 0%,rgba(15,23,42,.6) 100%);border:1px solid rgba(99,102,241,.25);border-radius:1rem;padding:.75rem 1rem;display:flex;align-items:center;gap:.75rem}
         /* Elite requirement badge */
         .elite-req{background:rgba(239,68,68,.08);border:1px solid rgba(239,68,68,.2);border-radius:.75rem;padding:.5rem .75rem;font-size:.65rem;font-weight:800;color:#fca5a5;text-transform:uppercase;letter-spacing:.06em}
         /* Milestone modal */
-        #milestone-modal{position:fixed;inset:0;background:rgba(2,6,23,.92);z-index:99998;backdrop-filter:blur(20px);display:none;align-items:center;justify-content:center;padding:2rem}
+        #milestone-modal{position:fixed;inset:0;background:rgba(2,6,23,.97);z-index:99998;backdrop-filter:blur(20px);display:none;align-items:center;justify-content:center;padding:2rem}
         #milestone-modal.show{display:flex}
         .milestone-inner{background:linear-gradient(145deg,rgba(30,41,59,.8) 0%,rgba(15,23,42,.95) 100%);border:1px solid rgba(250,204,21,.3);border-top:1px solid rgba(250,204,21,.5);border-radius:2rem;padding:2rem;text-align:center;max-width:20rem;width:100%;box-shadow:0 0 80px rgba(250,204,21,.1)}
         @keyframes burst{0%{transform:scale(.6);opacity:0}60%{transform:scale(1.1)}100%{transform:scale(1);opacity:1}}
@@ -468,9 +468,15 @@
         </div>
         <div id="deload-banner" class="deload-banner mx-2 hidden"><i class="fas fa-battery-quarter text-orange-400 text-lg flex-shrink-0"></i><div><p class="text-orange-300 text-[10px] font-black uppercase tracking-widest">Deload Week Active</p><p class="text-slate-400 text-[11px] mt-0.5">Sets reduced by 1, duration cut 40%. Let the tissue consolidate.</p></div></div>
         <div class="calendar-container px-2"><div class="calendar-grid" id="dashboard-grid"></div></div>
-        <div id="last-measure-row" class="hidden flex gap-3 mx-2">
+        <p class="text-[9px] font-black text-slate-700 text-center tracking-widest uppercase px-2">Tap any day to change training type</p>
+        <div id="last-measure-row" class="flex gap-3 mx-2">
             <div class="stat-chip flex-1"><p class="text-[9px] font-black text-blue-400 uppercase tracking-widest mb-1">Last BPEL</p><p id="last-bpel" class="text-lg font-black text-white" style="font-family:'JetBrains Mono',monospace">—</p></div>
             <div class="stat-chip flex-1"><p class="text-[9px] font-black text-emerald-400 uppercase tracking-widest mb-1">Last MSEG</p><p id="last-mseg" class="text-lg font-black text-white" style="font-family:'JetBrains Mono',monospace">—</p></div>
+        </div>
+        <!-- Coach Tee Daily Tip -->
+        <div class="tip-card mx-2">
+            <p class="text-[9px] font-black text-purple-400 uppercase tracking-widest mb-1.5 flex items-center gap-1.5"><i class="fas fa-comment-dots"></i> Coach Tee — Today</p>
+            <p id="daily-tip" class="text-[12px] text-slate-300 leading-relaxed italic"></p>
         </div>
         <!-- Hydration Tracker -->
         <div class="instruction-card mx-2 border-blue-500/15" style="padding:1rem;">
@@ -500,13 +506,6 @@
             </div>
             <p id="hydration-msg" class="text-[10px] text-slate-500 italic mt-1 text-center">Sip throughout the day — don't chug.</p>
         </div>
-
-```
-    <!-- Coach Tee Daily Tip -->
-    <div class="tip-card mx-2">
-        <p class="text-[9px] font-black text-purple-400 uppercase tracking-widest mb-1.5 flex items-center gap-1.5"><i class="fas fa-comment-dots"></i> Coach Tee — Today</p>
-        <p id="daily-tip" class="text-[12px] text-slate-300 leading-relaxed italic"></p>
-    </div>
 
     <!-- Sleep + Soreness quick-log -->
     <div class="px-2 space-y-2">
@@ -789,19 +788,18 @@
     <!-- EQ check-in -->
     <div class="instruction-card border-blue-500/20 mx-2 text-left">
         <p class="text-[11px] font-black text-blue-400 uppercase tracking-widest mb-3 flex items-center gap-2"><i class="fas fa-gauge-high"></i> EQ During Session</p>
-        <div class="flex gap-1.5" id="eq-checkin-btns">
-            <button class="eq-btn" data-eq="1">1</button>
+        <div class="grid grid-cols-5 gap-1.5" id="eq-checkin-btns">
+            <button class="eq-btn" data-eq="1">1<br><span class="text-[9px] font-normal opacity-60">Flaccid</span></button>
             <button class="eq-btn" data-eq="2">2</button>
             <button class="eq-btn" data-eq="3">3</button>
             <button class="eq-btn" data-eq="4">4</button>
-            <button class="eq-btn" data-eq="5">5</button>
+            <button class="eq-btn" data-eq="5">5<br><span class="text-[9px] font-normal opacity-60">Semi</span></button>
             <button class="eq-btn" data-eq="6">6</button>
             <button class="eq-btn" data-eq="7">7</button>
             <button class="eq-btn" data-eq="8">8</button>
             <button class="eq-btn" data-eq="9">9</button>
-            <button class="eq-btn" data-eq="10">10</button>
+            <button class="eq-btn" data-eq="10">10<br><span class="text-[9px] font-normal opacity-60">Full</span></button>
         </div>
-        <p class="text-[10px] text-slate-600 italic mt-2">1 = flaccid · 5 = semi · 10 = fully erect</p>
     </div>
 
     <!-- RPE -->
@@ -914,7 +912,7 @@
             </div>
         </div>
         <h2 class="text-3xl font-black italic uppercase text-white mb-3">What is EQ?</h2>
-        <p class="text-slate-400 text-sm leading-relaxed max-w-xs">EQ is your Erection Quality on a scale of 1–10. It tells the app how primed your tissue is for each exercise. Each exercise has a target EQ range — too soft means no pressure, too hard means overload risk.</p>
+        <p class="text-slate-400 text-sm leading-relaxed max-w-xs">EQ (Erection Quality) is a 1–10 scale you rate yourself at the start of each set. The app uses it to match intensity to your tissue readiness — too soft means no effective pressure, too firm risks overload.</p>
         <div class="mt-6 grid grid-cols-3 gap-3 w-full max-w-xs">
             <div class="p-2.5 rounded-xl bg-slate-800/60 border border-slate-700 text-center"><p class="text-xl font-black text-slate-300">1–4</p><p class="text-[9px] text-slate-500 mt-0.5">Length work</p></div>
             <div class="p-2.5 rounded-xl bg-blue-500/10 border border-blue-500/20 text-center"><p class="text-xl font-black text-blue-300">6–7</p><p class="text-[9px] text-blue-400 mt-0.5">Jelq / Uli</p></div>
@@ -930,14 +928,13 @@
             </div>
         </div>
         <h2 class="text-3xl font-black italic uppercase text-white mb-3">Start at Beginner</h2>
-        <p class="text-slate-400 text-sm leading-relaxed max-w-xs">The app has 4 difficulty tiers. Every new user starts at Beginner regardless of experience. Higher tiers unlock after 4 weeks — this protects your tissue from adapting faster than it can handle. On rest days, do the Recovery Protocol.</p>
+        <p class="text-slate-400 text-sm leading-relaxed max-w-xs">The app has 4 tiers: Beginner → Intermediate → Advanced → Elite. Everyone starts at Beginner. Each tier requires 4 weeks of consistent training before the next unlocks — this lets your tissue adapt safely. On rest days, always do the Recovery Protocol.</p>
         <div class="mt-6 p-4 rounded-2xl bg-amber-500/08 border border-amber-500/20 text-left max-w-xs w-full">
             <p class="text-amber-300 text-[10px] font-black uppercase tracking-widest mb-1">CoachTee Says</p>
             <p class="text-slate-400 text-xs leading-relaxed">The guys who try to skip to Advanced in week one are the same guys who quit in week three. Trust the process.</p>
         </div>
     </div>
 
-```
 <!-- Nav -->
 <div class="absolute bottom-0 left-0 right-0 p-8 flex flex-col items-center gap-4">
     <div class="flex gap-2" id="ob-dots">
@@ -946,9 +943,8 @@
         <div class="ob-dot"></div>
     </div>
     <button id="ob-next-btn" class="btn-primary py-5 w-full max-w-xs">Next</button>
-    <button id="ob-skip-btn" class="text-slate-600 text-[10px] font-bold uppercase tracking-widest">Skip intro</button>
+    <button id="ob-skip-btn" class="text-slate-500 text-[10px] font-bold uppercase tracking-widest">Skip intro</button>
 </div>
-```
 
 </div>
 
@@ -2729,9 +2725,10 @@ function renderDashboard(){
     document.getElementById('hq-level-bar').style.width=`${lvl.pct}%`;
     document.getElementById('hq-level-next').innerText=lvl.isMax?'MAX LEVEL':`${lvl.xpToNext} XP to next rank`;
     document.getElementById('deload-banner').classList.toggle('hidden',!isDeloadWeek());
-    const meas=persisted.measurements||[],lmr=document.getElementById('last-measure-row');
-    if(meas.length){const last=meas[meas.length-1];lmr.classList.remove('hidden');document.getElementById('last-bpel').innerText=last.bpel?`${last.bpel}"`:'—';document.getElementById('last-mseg').innerText=last.mseg?`${last.mseg}"`:'—'}
-    else lmr.classList.add('hidden');
+    const meas=persisted.measurements||[];
+    const last=meas.length?meas[meas.length-1]:null;
+    document.getElementById('last-bpel').innerText=last?.bpel?`${last.bpel}"`:'—';
+    document.getElementById('last-mseg').innerText=last?.mseg?`${last.mseg}"`:'—';
     renderLog();
     renderRecords();
     renderDailyTip();
@@ -3146,7 +3143,7 @@ async function handlePasswordReset(){
         if(pwd.length<6){errEl.innerText='Password must be at least 6 characters.';errEl.classList.add('show');return}
         if(pwd!==conf){errEl.innerText='Passwords do not match.';errEl.classList.add('show');return}
         const btn=document.getElementById('pwd-reset-submit-btn');
-        btn.textContent='Updating...';btn.disabled=true;
+        btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i>Updating...';btn.disabled=true;
         const {error}=await sb.auth.updateUser({password:pwd});
         if(error){errEl.innerText=error.message;errEl.classList.add('show');btn.textContent='UPDATE PASSWORD';btn.disabled=false;}
         else{
@@ -3182,7 +3179,7 @@ async function handleAuthSubmit(){
     const btn=document.getElementById('auth-submit-btn');
     if(!email||!password){setAuthError('Please enter your email and password.');return}
     if(authMode==='signup'&&password!==confirm){setAuthError('Passwords do not match.');return}
-    btn.textContent='Please wait...';btn.disabled=true;setAuthError('');
+    btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i>Please wait...';btn.disabled=true;setAuthError('');
 
     try{
         let result;
@@ -3354,7 +3351,20 @@ function init(){
     document.getElementById('recovery-select-all-btn').addEventListener('click',selectAllRecovery);
     document.getElementById('recovery-select-daily-btn').addEventListener('click',selectDailyRecommended);
     document.getElementById('recovery-start-btn').addEventListener('click',startRecoverySession);
-    document.getElementById('mission-abort-btn').addEventListener('click',()=>goToStep(0));
+    let _abortPrimed=false,_abortTimer=null;
+    document.getElementById('mission-abort-btn').addEventListener('click',()=>{
+        const btn=document.getElementById('mission-abort-btn');
+        if(!_abortPrimed){
+            _abortPrimed=true;
+            btn.innerText='Tap again to confirm abort';
+            btn.style.color='#ef4444';
+            _abortTimer=setTimeout(()=>{_abortPrimed=false;btn.innerText='Abort Session';btn.style.color='';},3000);
+        } else {
+            clearTimeout(_abortTimer);_abortPrimed=false;
+            btn.innerText='Abort Session';btn.style.color='';
+            goToStep(0);
+        }
+    });
     // Pilot Engine
     document.getElementById('ex-abort-btn').addEventListener('click',()=>goToStep(0));
     document.getElementById('ex-back-btn').addEventListener('click',()=>{


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Loading spinners** on auth and password-reset buttons while async requests are in flight
- **Modal backdrop opacity** standardised to `rgba(2,6,23,.97)` across milestone and soreness modals
- **Onboarding EQ slide** — clarified that EQ is rated at the start of each set, with target ranges shown
- **Onboarding difficulty slide** — shows full tier progression (Beginner → Intermediate → Advanced → Elite) and 4-week requirement per tier
- **Skip button** visibility improved (`slate-600` → `slate-500`)
- **Stray backtick fences** removed from onboarding nav HTML

Also includes all prior fixes on this branch:
- ISO week year-boundary bug fix + test suite (21 tests)
- Stale cue text fix (Uli showing "pull out" from previous session)
- Cue progression fix (cues now advance correctly through a set)
- Streak calculation using consecutive session days instead of weekly reset
- Deload week guard (requires 4 weeks of training history)
- V-Stretch howto steps added
- EQ buttons redesigned to 2×5 grid with Flaccid/Semi/Full labels
- 2-tap abort confirmation on mobile
- Dashboard: daily tip moved above hydration, measurements always visible, calendar tap hint added

## Test plan

- [ ] Sign in — spinner appears on button during login
- [ ] Sign up — spinner appears during account creation
- [ ] Password reset — spinner appears while updating
- [ ] Open onboarding (clear localStorage) — check EQ and difficulty slide copy
- [ ] Trigger soreness warning and milestone modal — check backdrop opacity is fully opaque
- [ ] Start a session, tap Abort — confirm 2-tap pattern still works
- [ ] Run `npm test` — all 21 ISO week tests pass

https://claude.ai/code/session_0199ikpCsXKTAT16nM3ELXB2
EOF
)