### PR TITLE
Fix login/logout, timer screen lock, notifications, and Whop access

### DIFF
--- a/functions/api/whop-webhook.js
+++ b/functions/api/whop-webhook.js
@@ -1,0 +1,77 @@
+// Whop membership webhook
+// Grants access on purchase, revokes on cancellation/refund.
+//
+// Required secrets (add in Cloudflare Pages → Settings → Variables and Secrets):
+//   WHOP_WEBHOOK_SECRET      — Whop dashboard → Developer → Webhooks → signing secret
+//   SUPABASE_URL             — your Supabase project URL
+//   SUPABASE_SERVICE_ROLE_KEY — Supabase → Project Settings → API → service_role
+
+async function verifyWhopSignature(secret, rawBody, signatureHeader) {
+  if (!signatureHeader) return false;
+  const parts = Object.fromEntries(signatureHeader.split(',').map(p => p.split('=')));
+  const { t: timestamp, v0: receivedHex } = parts;
+  if (!timestamp || !receivedHex) return false;
+  if (Math.abs(Date.now() / 1000 - Number(timestamp)) > 300) return false; // reject replays > 5 min old
+
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(`${timestamp}.${rawBody}`));
+  const expectedHex = Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return expectedHex === receivedHex;
+}
+
+async function upsertMember(email, supabaseUrl, serviceKey) {
+  const res = await fetch(`${supabaseUrl}/rest/v1/members`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'resolution=merge-duplicates,return=minimal',
+    },
+    body: JSON.stringify([{ email }]),
+  });
+  if (!res.ok) throw new Error(`Supabase upsert failed: ${res.status}`);
+}
+
+async function deleteMember(email, supabaseUrl, serviceKey) {
+  const res = await fetch(`${supabaseUrl}/rest/v1/members?email=eq.${encodeURIComponent(email)}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+    },
+  });
+  if (!res.ok) throw new Error(`Supabase delete failed: ${res.status}`);
+}
+
+export async function onRequestPost({ request, env }) {
+  const rawBody = await request.text();
+  const sigHeader = request.headers.get('Whop-Signature');
+
+  const valid = await verifyWhopSignature(env.WHOP_WEBHOOK_SECRET, rawBody, sigHeader);
+  if (!valid) return new Response('Unauthorized', { status: 401 });
+
+  let payload;
+  try { payload = JSON.parse(rawBody); } catch { return new Response('Bad JSON', { status: 400 }); }
+
+  const event = payload.event || payload.action;
+  const email = payload.data?.user?.email || payload.data?.email;
+
+  if (email) {
+    try {
+      if (event === 'membership.went_valid') {
+        await upsertMember(email, env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+      } else if (event === 'membership.went_invalid') {
+        await deleteMember(email, env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+      }
+    } catch (e) {
+      console.error('Webhook DB error:', e);
+      return new Response('Internal error', { status: 500 });
+    }
+  }
+
+  return new Response('OK', { status: 200 });
+}

--- a/functions/api/whop-webhook.js
+++ b/functions/api/whop-webhook.js
@@ -62,9 +62,9 @@ export async function onRequestPost({ request, env }) {
 
   if (email) {
     try {
-      if (event === 'membership.went_valid') {
+      if (event === 'membership_activated' || event === 'membership.went_valid') {
         await upsertMember(email, env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
-      } else if (event === 'membership.went_invalid') {
+      } else if (event === 'membership_deactivated' || event === 'membership.went_invalid') {
         await deleteMember(email, env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
       }
     } catch (e) {

--- a/index.html
+++ b/index.html
@@ -1895,29 +1895,41 @@ function getCurrentWeekKey(){ return _getISOYear()+'_w'+getISOWeek(); }
 
 async function loadPersisted(){
     if(!currentUser)return;
+    // Read localStorage backup first so we can compare timestamps
+    let localData=null;
+    try{const raw=localStorage.getItem('bp_data_'+currentUser.id);if(raw)localData=JSON.parse(raw);}catch(e){}
     try{
         const {data,error} = await sb.from('user_data').select('*').eq('id',currentUser.id).single();
         if(error||!data){
-            // Fall back to localStorage backup
-            const local=localStorage.getItem('bp_data_'+currentUser.id);
-            if(local) try{persisted={...DEFAULT_PERSISTED,...JSON.parse(local)};}catch(e){}
+            if(localData) try{const {_savedAt:_,...rest}=localData;persisted={...DEFAULT_PERSISTED,...rest};}catch(e){}
             return;
         }
-        persisted = {
-            schedule:       data.schedule        || DEFAULT_PERSISTED.schedule,
-            completedDays:  data.completed_days  || DEFAULT_PERSISTED.completedDays,
-            totalXp:        data.total_xp        || 0,
-            sessionLog:     data.session_log     || [],
-            measurements:   data.measurements    || [],
-            seenMilestones: data.seen_milestones || [],
-            difficulty:     data.difficulty      || 'intermediate',
-            diffUnlockedDate: data.diff_unlocked_date || {intermediate:'',advanced:'',elite:''},
-            firstSessionDate: data.first_session_date || '',
-            weekKey:        data.week_key        || '',
-            records:        data.records         || {longestStreak:0,bestWeekXp:0,bestSessionXp:0},
-            tipIndex:       data.tip_index       || 0,
-            lastTipDate:    data.last_tip_date   || '',
-        };
+        // If the local backup is strictly newer than the Supabase row, use it — the
+        // last Supabase write may have silently failed (PWA / flaky mobile network).
+        const dbTime=new Date(data.updated_at||0).getTime();
+        const localTime=localData?new Date(localData._savedAt||0).getTime():0;
+        if(localTime>dbTime && localData){
+            const {_savedAt:_,...rest}=localData;
+            persisted={...DEFAULT_PERSISTED,...rest};
+            // Re-sync Supabase with the newer local data
+            try{await sb.from('user_data').upsert(_upsertPayload(),{onConflict:'id'});}catch(e){}
+        } else {
+            persisted = {
+                schedule:       data.schedule        || DEFAULT_PERSISTED.schedule,
+                completedDays:  data.completed_days  || DEFAULT_PERSISTED.completedDays,
+                totalXp:        data.total_xp        || 0,
+                sessionLog:     data.session_log     || [],
+                measurements:   data.measurements    || [],
+                seenMilestones: data.seen_milestones || [],
+                difficulty:     data.difficulty      || 'intermediate',
+                diffUnlockedDate: data.diff_unlocked_date || {intermediate:'',advanced:'',elite:''},
+                firstSessionDate: data.first_session_date || '',
+                weekKey:        data.week_key        || '',
+                records:        data.records         || {longestStreak:0,bestWeekXp:0,bestSessionXp:0},
+                tipIndex:       data.tip_index       || 0,
+                lastTipDate:    data.last_tip_date   || '',
+            };
+        }
         // Auto-reset completedDays if we're in a new week
         const currentWeek = getCurrentWeekKey();
         if(persisted.weekKey !== currentWeek){
@@ -1927,8 +1939,7 @@ async function loadPersisted(){
         }
     }catch(e){
         console.error('loadPersisted:',e);
-        const local=localStorage.getItem('bp_data_'+currentUser.id);
-        if(local) try{persisted={...DEFAULT_PERSISTED,...JSON.parse(local)};}catch(e2){}
+        if(localData) try{const {_savedAt:_,...rest}=localData;persisted={...DEFAULT_PERSISTED,...rest};}catch(e2){}
     }
 }
 
@@ -1955,8 +1966,8 @@ function _upsertPayload(){
     return{id:currentUser.id,..._buildSavePayload()};
 }
 function savePersisted(){
-    // Always write to localStorage immediately as backup
-    if(currentUser) try{localStorage.setItem('bp_data_'+currentUser.id,JSON.stringify(persisted));}catch(e){}
+    // Always write to localStorage immediately as backup (with timestamp so loadPersisted can prefer newer source)
+    if(currentUser) try{localStorage.setItem('bp_data_'+currentUser.id,JSON.stringify({...persisted,_savedAt:new Date().toISOString()}));}catch(e){}
     // Debounce the Supabase write
     clearTimeout(_saveDebounce);
     _saveDebounce = setTimeout(async()=>{
@@ -1969,7 +1980,7 @@ function _flushSaveNow(){
     // Called on visibility hidden — fire Supabase write immediately without debounce
     if(!currentUser)return;
     clearTimeout(_saveDebounce);
-    try{localStorage.setItem('bp_data_'+currentUser.id,JSON.stringify(persisted));}catch(e){}
+    try{localStorage.setItem('bp_data_'+currentUser.id,JSON.stringify({...persisted,_savedAt:new Date().toISOString()}));}catch(e){}
     sb.from('user_data').upsert(_upsertPayload(),{onConflict:'id'}).catch(()=>{});
 }
 
@@ -3733,7 +3744,8 @@ async function handleAuthSubmit(){
     try{
         let result;
         if(authMode==='login'){
-            result=await sb.auth.signInWithPassword({email,password});
+            const _timeout=new Promise((_,rej)=>setTimeout(()=>rej(new Error('Connection timed out. Check your network and try again.')),20000));
+            result=await Promise.race([sb.auth.signInWithPassword({email,password}),_timeout]);
             if(!result.error){
                 if(_rememberMe)localStorage.setItem('bp_remember_email',email);
                 else localStorage.removeItem('bp_remember_email');

--- a/index.html
+++ b/index.html
@@ -3798,11 +3798,15 @@ async function handleForgotPassword(){
     else setAuthSuccess('Password reset email sent. Check your inbox.');
 }
 async function handleLogout(){
-    _flushSaveNow(); // ensure pending changes reach Supabase before signing out
-    await sb.auth.signOut();
+    // Clear state and show auth screen immediately — don't wait on the network.
+    // Any in-flight onUserSignedIn will see currentUser cleared and abort.
     currentUser=null;persisted={...DEFAULT_PERSISTED};
+    clearTimeout(_localNotifTimer);_localNotifTimer=null;
+    _releaseWakeLock();
     showAuthScreen();
     document.querySelectorAll('.step-content').forEach(s=>{s.classList.add('hidden-step');s.classList.remove('active-step')});
+    _flushSaveNow();
+    try{await sb.auth.signOut();}catch(e){console.error('signOut error:',e);}
 }
 async function checkMembership(user){
     // Check members table in Supabase — you add rows manually or via Whop webhook later
@@ -3822,29 +3826,38 @@ async function checkMembership(user){
     }
 }
 
+let _signingIn=false;
 async function onUserSignedIn(user){
-    // Only skip re-init if the app is already showing for this user (e.g. TOKEN_REFRESHED).
-    // If the auth screen is visible, always run the full init — the guard was previously
-    // firing when currentUser was stale from a prior session, leaving users stuck on sign-in.
+    // Prevent concurrent calls (handleAuthSubmit + onAuthStateChange both call this on login).
+    // A concurrent second call for the same user is always redundant — skip it.
+    if(_signingIn && currentUser?.id===user.id) return;
     const authVisible=!document.getElementById('auth-screen').classList.contains('hidden');
     if(currentUser?.id===user.id && !authVisible) return;
-    currentUser=user;
-    // Check membership
-    const isMember=await checkMembership(user);
-    if(!isMember){currentUser=null;return;}
-    document.getElementById('hq-user-email').textContent=user.email;
-    await loadPersisted();
-    _scheduleLocalNotif(); // re-arm scheduler now that persisted data is loaded
-    hideAuthScreen();
-    const welcomed=localStorage.getItem('bp_welcomed_'+user.id);
-    const onboarded=localStorage.getItem('bp_onboarded_'+user.id);
-    if(welcomed){
-        goToStep(0);
-        if(!onboarded) setTimeout(showOnboarding, 600);
-    } else {
-        document.querySelectorAll('.step-content').forEach(s=>{s.classList.add('hidden-step');s.classList.remove('active-step')});
-        const w=document.getElementById('step-welcome');
-        w.classList.remove('hidden-step');w.classList.add('active-step');
+    _signingIn=true;
+    try{
+        currentUser=user;
+        const isMember=await checkMembership(user);
+        // Bail if logout happened while we were awaiting
+        if(currentUser?.id!==user.id) return;
+        if(!isMember){currentUser=null;return;}
+        document.getElementById('hq-user-email').textContent=user.email;
+        await loadPersisted();
+        // Bail if logout happened while we were awaiting
+        if(currentUser?.id!==user.id) return;
+        _scheduleLocalNotif();
+        hideAuthScreen();
+        const welcomed=localStorage.getItem('bp_welcomed_'+user.id);
+        const onboarded=localStorage.getItem('bp_onboarded_'+user.id);
+        if(welcomed){
+            goToStep(0);
+            if(!onboarded) setTimeout(showOnboarding,600);
+        } else {
+            document.querySelectorAll('.step-content').forEach(s=>{s.classList.add('hidden-step');s.classList.remove('active-step')});
+            const w=document.getElementById('step-welcome');
+            w.classList.remove('hidden-step');w.classList.add('active-step');
+        }
+    }finally{
+        _signingIn=false;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -1995,6 +1995,22 @@ function resetSession(){
     session.exerciseIndex=0;session.setIndex=1;session.directionalIndex=0;session.xp=0;
     session.recoveryQueue=null;session.recoveryQueuePos=0;
     session.girthRound=1;session.girthTotalRounds=3;
+    _releaseWakeLock();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SCREEN WAKE LOCK — keeps screen on while a timer is actively counting
+// ═══════════════════════════════════════════════════════════════════════════
+let _wakeLock=null;
+async function _acquireWakeLock(){
+    if(!('wakeLock' in navigator)||_wakeLock)return;
+    try{_wakeLock=await navigator.wakeLock.request('screen');_wakeLock.addEventListener('release',()=>{_wakeLock=null;});}catch(e){}
+}
+function _releaseWakeLock(){if(_wakeLock){_wakeLock.release().catch(()=>{});_wakeLock=null;}}
+// Call after any timer state change — acquires if any timer is running, releases if none are.
+function _syncWakeLock(){
+    const active=(session.timer?.isRunning())||(session.warmupTimer?.isRunning());
+    if(active)_acquireWakeLock();else _releaseWakeLock();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -2548,12 +2564,12 @@ function resetWarmupUI(){document.getElementById('warmup-timer').innerText='10:0
 function toggleWarmup(){
     const btn=document.getElementById('warmup-btn');
     if(!session.warmupTimer){
-        session.warmupTimer=createTimer(600,rem=>{const m=Math.floor(rem/60).toString().padStart(2,'0'),s=(rem%60).toString().padStart(2,'0');document.getElementById('warmup-timer').innerText=`${m}:${s}`},()=>{btn.innerText='Complete!';haptic([80,40,80,40,200]);setTimeout(()=>nextStep(),800)});
-        session.warmupTimer.start();btn.innerText='Pause';
-    }else if(session.warmupTimer.isRunning()){session.warmupTimer.pause();btn.innerText='Resume'}
-    else{session.warmupTimer.resume();btn.innerText='Pause'}
+        session.warmupTimer=createTimer(600,rem=>{const m=Math.floor(rem/60).toString().padStart(2,'0'),s=(rem%60).toString().padStart(2,'0');document.getElementById('warmup-timer').innerText=`${m}:${s}`},()=>{btn.innerText='Complete!';haptic([80,40,80,40,200]);_syncWakeLock();setTimeout(()=>nextStep(),800)});
+        session.warmupTimer.start();btn.innerText='Pause';_syncWakeLock();
+    }else if(session.warmupTimer.isRunning()){session.warmupTimer.pause();btn.innerText='Resume';_syncWakeLock();}
+    else{session.warmupTimer.resume();btn.innerText='Pause';_syncWakeLock();}
 }
-function stopWarmup(){if(session.warmupTimer){session.warmupTimer.cancel();session.warmupTimer=null}resetWarmupUI()}
+function stopWarmup(){if(session.warmupTimer){session.warmupTimer.cancel();session.warmupTimer=null}resetWarmupUI();_syncWakeLock();}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // EXERCISE ENGINE
@@ -2972,7 +2988,7 @@ function startSet(){
             if(activeCue) updateActiveCue(activeCue.text.replace('{DIR}',DIRECTIONALS[session.directionalIndex]));
         }
     },()=>onSetDone());
-    session.timer.start();
+    session.timer.start();_syncWakeLock();
 }
 function pauseResumeSet(){
     if(!session.timer)return;
@@ -2983,6 +2999,7 @@ function pauseResumeSet(){
         stopJelqStrokePacer();
         ic.className='fas fa-play text-4xl text-slate-300';
         if(lbl)lbl.innerText='Resume';
+        _syncWakeLock();
     } else {
         session.timer.resume();
         // Restart pacer if this is a Wet Jelq set
@@ -2990,13 +3007,14 @@ function pauseResumeSet(){
         if(ex.title==='Wet Jelq') startJelqStrokePacer();
         ic.className='fas fa-pause text-4xl text-slate-300';
         if(lbl)lbl.innerText='Pause';
+        _syncWakeLock();
     }
 }
 function onSetDone(){
     stopJelqStrokePacer();
     document.getElementById('ex-pause-btn').style.display='none';
     setFocusedMode(false);
-    session.timer=null;
+    session.timer=null;_syncWakeLock();
     haptic([60,30,60]);
     const ex=getCurEx();
     if(ex.isDirectional&&session.directionalIndex<DIRECTIONALS.length-1){session.directionalIndex++;document.getElementById('ex-timer').innerText=fmtDuration(ex.duration);updateExUI();}
@@ -3088,13 +3106,13 @@ function startRest(){
     },()=>{
         ov.classList.add('hidden');
         stopBoxBreathing();
-        session.timer=null;session.setIndex++;updateExUI();haptic([100]);
+        session.timer=null;_syncWakeLock();session.setIndex++;updateExUI();haptic([100]);
     });
-    session.timer.start();
+    session.timer.start();_syncWakeLock();
 }
 function skipRest(){
     if(session.timer){session.timer.cancel();session.timer=null}
-    stopBoxBreathing();
+    stopBoxBreathing();_syncWakeLock();
     document.getElementById('rest-overlay').classList.add('hidden');
     session.setIndex++;updateExUI();
 }
@@ -3148,11 +3166,11 @@ function startGirthRoundRest(){
         document.getElementById('rest-timer').innerText=rem;
         if(arc) arc.style.strokeDashoffset=String((1-(rem/restDur))*circumference);
     },()=>{
-        ov.classList.add('hidden');stopBoxBreathing();session.timer=null;
+        ov.classList.add('hidden');stopBoxBreathing();session.timer=null;_syncWakeLock();
         session.exerciseIndex=0;session.setIndex=1;session.directionalIndex=0;
         updateExUI();haptic([100]);
     });
-    session.timer.start();
+    session.timer.start();_syncWakeLock();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -4177,9 +4195,10 @@ document.addEventListener('DOMContentLoaded', async ()=>{
         if(!session) showAuthScreen();
     }
 
-    // Save on tab hide (catches closed browser mid-session) — use flush, not debounce
+    // Save on tab hide; re-acquire wake lock when screen comes back on mid-timer
     document.addEventListener('visibilitychange',()=>{
         if(document.visibilityState==='hidden') _flushSaveNow();
+        else _syncWakeLock(); // wake lock is auto-released on hide; reclaim it if a timer is still running
     });
 });
 </script>

--- a/index.html
+++ b/index.html
@@ -3834,6 +3834,7 @@ async function onUserSignedIn(user){
     if(!isMember){currentUser=null;return;}
     document.getElementById('hq-user-email').textContent=user.email;
     await loadPersisted();
+    _scheduleLocalNotif(); // re-arm scheduler now that persisted data is loaded
     hideAuthScreen();
     const welcomed=localStorage.getItem('bp_welcomed_'+user.id);
     const onboarded=localStorage.getItem('bp_onboarded_'+user.id);
@@ -3854,13 +3855,85 @@ const VAPID_PUBLIC_KEY='BHNs21bsR6oKAN19h2o7tSH5s5QHEB3YCqrxaZ6WmMQ6zMJEeuPC7gZ0
 function _urlBase64ToUint8(b64){const p=(b64+'='.repeat((4-b64.length%4)%4)).replace(/-/g,'+').replace(/_/g,'/');const raw=atob(p);return Uint8Array.from([...raw].map(c=>c.charCodeAt(0)));}
 let _swRegistration=null;
 async function initServiceWorker(){
-    if(!('serviceWorker' in navigator)||!('PushManager' in window))return;
+    if(!('serviceWorker' in navigator))return;
     try{_swRegistration=await navigator.serviceWorker.register('/sw.js');}
     catch(e){console.error('SW register:',e);}
 }
+
+// ── Local notification scheduler ──────────────────────────────────────────
+// Fires at the user-set time directly from the browser — no server needed.
+// Works as long as the PWA or browser tab is running. Re-schedules daily.
+let _localNotifTimer=null;
+
+const _NOTIF_MSGS={
+    rest:[
+        {title:'Recovery day.',body:'Hip flexors + RK holds. 5 minutes locks in the gains.'},
+        {title:'Active recovery today.',body:'Pelvic floor release + box breathing. 5 min. Do it.'},
+        {title:'Rest day protocol.',body:'Reverse kegels + hip openers. Recovery work compounds.'},
+        {title:'5-min recovery session.',body:'Stretch, breathe, release. Your tissue rebuilds tonight.'},
+        {title:'Recovery is the work.',body:'Drop into pelvic floor release + RK holds. 5 minutes.'},
+        {title:'Open The Blueprint.',body:'Recovery Protocol today — pelvic stretches + RK holds.'},
+        {title:'Rest day. Do the work.',body:'Hip openers + reverse kegels keep the floor supple.'},
+    ],
+    streak:[
+        (s)=>({title:`Day ${s+1}. Keep it moving.`,body:'Warm up, hit the protocol, log it. Streak stays alive.'}),
+        (s)=>({title:`${s}-day streak on the line.`,body:'One session keeps the chain unbroken. Open the app.'}),
+        (s)=>({title:`Day ${s+1}.`,body:'Consistent reps compound. Do not let today be the gap.'}),
+        (s)=>({title:`${s} days straight.`,body:'Warmup → protocol → done. That is the whole move.'}),
+        (s)=>({title:`Streak alive: ${s} days.`,body:'Tissue adapts in recovery. Give it the stimulus first.'}),
+        (s)=>({title:`Day ${s+1}. You know the drill.`,body:'10 minutes of warmup and the work is half done.'}),
+        (s)=>({title:`${s} days in.`,body:'This is where most guys stop. You are not most guys.'}),
+    ],
+    train:[
+        {title:'Time to train.',body:'10-min warmup → protocol → done. Open The Blueprint.'},
+        {title:'Your tissue is ready.',body:'Nothing left but the work. Open the app and get it done.'},
+        {title:'Consistency is the protocol.',body:'One session today keeps the adaptation cycle running.'},
+        {title:'Get the session in.',body:'Warm up, execute, recover. That is the whole job.'},
+        {title:'Progress is made tonight.',body:'Collagen remodels 48–72 h after the stimulus. Give it one.'},
+        {title:'Open The Blueprint.',body:'Start the warmup. The rest follows.'},
+        {title:'One session. That is it.',body:'Warmup, work, done. Your future self does not skip.'},
+    ],
+};
+
+function _buildNotifPayload(){
+    const day=new Date().getDay();
+    const todayKey=new Date().toISOString().split('T')[0];
+    const trained=(persisted?.sessionLog||[]).some(s=>s.date?.startsWith(todayKey));
+    if(trained) return null;
+    const todayType=(persisted?.schedule||[])[day]||'rest';
+    const isRest=todayType==='rest';
+    if(isRest) return _NOTIF_MSGS.rest[day%7];
+    const streak=getCurrentStreak();
+    if(streak>0) return _NOTIF_MSGS.streak[day%7](streak);
+    return _NOTIF_MSGS.train[day%7];
+}
+
+async function _fireLocalNotif(){
+    const payload=_buildNotifPayload();
+    if(payload){
+        const opts={body:payload.body,icon:'/icon-192.png',badge:'/badge-72.png',tag:'daily-reminder',data:{url:'/'},silent:false};
+        if(_swRegistration) await _swRegistration.showNotification(payload.title,opts).catch(()=>{});
+        else if(Notification.permission==='granted') new Notification(payload.title,{body:payload.body,icon:'/icon-192.png'});
+    }
+    _scheduleLocalNotif(); // re-arm for tomorrow
+}
+
+function _scheduleLocalNotif(){
+    clearTimeout(_localNotifTimer);_localNotifTimer=null;
+    if(Notification.permission!=='granted') return;
+    const prefs=JSON.parse(localStorage.getItem('bp_notif_prefs')||'{}');
+    if(!prefs.time) return;
+    const [h,m]=prefs.time.split(':').map(Number);
+    const now=new Date();
+    const target=new Date(now);
+    target.setHours(h,m,0,0);
+    if(target<=now) target.setDate(target.getDate()+1);
+    _localNotifTimer=setTimeout(_fireLocalNotif,target.getTime()-now.getTime());
+}
+
 function openNotifModal(){
     const modal=document.getElementById('notif-modal');
-    const supported='serviceWorker' in navigator && 'PushManager' in window;
+    const supported='Notification' in window && 'serviceWorker' in navigator;
     document.getElementById('notif-unsupported').classList.toggle('hidden',supported);
     document.getElementById('notif-supported').classList.toggle('hidden',!supported);
     if(supported) _refreshNotifUI();
@@ -3869,41 +3942,42 @@ function openNotifModal(){
 function closeNotifModal(){document.getElementById('notif-modal').classList.add('hidden');}
 async function _refreshNotifUI(){
     const perm=Notification.permission;
-    const sub=_swRegistration?await _swRegistration.pushManager.getSubscription():null;
-    const active=perm==='granted'&&!!sub;
+    const active=perm==='granted';
     document.getElementById('notif-enable-btn').classList.toggle('hidden',active);
     document.getElementById('notif-disable-btn').classList.toggle('hidden',!active);
     document.getElementById('notif-icon').className=active?'fas fa-bell text-xs text-blue-400':'fas fa-bell text-xs';
     document.getElementById('notif-btn').style.borderColor=active?'rgba(59,130,246,.4)':'';
     document.getElementById('notif-status').innerText=active?'Notifications are active.':perm==='denied'?'Notifications blocked in browser settings.':'';
-    // Load saved prefs
     const prefs=JSON.parse(localStorage.getItem('bp_notif_prefs')||'{}');
     if(prefs.time) document.getElementById('notif-time').value=prefs.time;
     const streakOn=prefs.streakWarn!==false;
     _setToggleUI('streak-warn-toggle','streak-warn-thumb',streakOn);
 }
-function _setToggleUI(id,thumbId,on){
-    const t=document.getElementById(id),th=document.getElementById(thumbId);
-    t.style.background=on?'#3b82f6':'';t.style.borderColor=on?'#3b82f6':'';
-    th.style.transform=on?'translateX(16px)':'';th.style.background=on?'#fff':'';
-}
 async function enableNotifications(){
-    if(!_swRegistration){document.getElementById('notif-status').innerText='Service worker not ready — try again.';return;}
     const btn=document.getElementById('notif-enable-btn');
     btn.innerHTML='<i class="fas fa-spinner fa-spin mr-2"></i>Requesting...';btn.disabled=true;
     try{
         const perm=await Notification.requestPermission();
         if(perm!=='granted'){document.getElementById('notif-status').innerText='Permission denied.';btn.innerHTML='Enable Notifications';btn.disabled=false;return;}
-        const sub=await _swRegistration.pushManager.subscribe({userVisibleOnly:true,applicationServerKey:_urlBase64ToUint8(VAPID_PUBLIC_KEY)});
-        await _savePushSubscription(sub);
+        // Local scheduler — works immediately, no server needed
+        _scheduleLocalNotif();
+        // Best-effort push subscription for server-side delivery (non-blocking)
+        if(_swRegistration&&'PushManager' in window){
+            try{
+                const sub=await _swRegistration.pushManager.subscribe({userVisibleOnly:true,applicationServerKey:_urlBase64ToUint8(VAPID_PUBLIC_KEY)});
+                await _savePushSubscription(sub);
+            }catch(e){/* push subscription optional — local scheduler already armed */}
+        }
         await _refreshNotifUI();
-    }catch(e){console.error('Push subscribe:',e);document.getElementById('notif-status').innerText='Could not enable — try again.';}
+    }catch(e){console.error('Enable notifications:',e);document.getElementById('notif-status').innerText='Could not enable — try again.';}
     btn.innerHTML='Enable Notifications';btn.disabled=false;
 }
 async function disableNotifications(){
-    if(!_swRegistration)return;
-    const sub=await _swRegistration.pushManager.getSubscription();
-    if(sub){await sub.unsubscribe();await _deletePushSubscription(sub);}
+    clearTimeout(_localNotifTimer);_localNotifTimer=null;
+    if(_swRegistration&&'PushManager' in window){
+        const sub=await _swRegistration.pushManager.getSubscription().catch(()=>null);
+        if(sub){await sub.unsubscribe().catch(()=>{});await _deletePushSubscription(sub);}
+    }
     await _refreshNotifUI();
 }
 async function _savePushSubscription(sub){
@@ -3930,10 +4004,11 @@ async function saveNotifPrefs(){
     const streakWarn=document.getElementById('streak-warn-toggle').style.background==='rgb(59, 130, 246)';
     const prefs={time,streakWarn};
     localStorage.setItem('bp_notif_prefs',JSON.stringify(prefs));
+    _scheduleLocalNotif(); // re-arm with new time
     // Update in Supabase if subscribed
-    if(currentUser){
-        const sub=_swRegistration?await _swRegistration.pushManager.getSubscription():null;
-        if(sub) await sb.from('push_subscriptions').update({reminder_time:time,streak_warn:streakWarn}).eq('user_id',currentUser.id);
+    if(currentUser&&_swRegistration&&'PushManager' in window){
+        const sub=await _swRegistration.pushManager.getSubscription().catch(()=>null);
+        if(sub) await sb.from('push_subscriptions').update({reminder_time:time,streak_warn:streakWarn}).eq('user_id',currentUser.id).catch(()=>{});
     }
 }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,8 +1,91 @@
+// ── Whop webhook signature verification ───────────────────────────────────
+// Whop sends:  Whop-Signature: t=<timestamp>,v0=<hex_hmac>
+// Signed string: "<timestamp>.<raw_body>"
+// Algorithm: HMAC-SHA256 with the webhook signing secret
+async function verifyWhopSignature(secret, rawBody, signatureHeader) {
+  if (!signatureHeader) return false;
+  const parts = Object.fromEntries(signatureHeader.split(',').map(p => p.split('=')));
+  const timestamp = parts.t;
+  const receivedHex = parts.v0;
+  if (!timestamp || !receivedHex) return false;
+
+  // Reject replays older than 5 minutes
+  if (Math.abs(Date.now() / 1000 - Number(timestamp)) > 300) return false;
+
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    'raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(`${timestamp}.${rawBody}`));
+  const expectedHex = Array.from(new Uint8Array(sig)).map(b => b.toString(16).padStart(2, '0')).join('');
+  return expectedHex === receivedHex;
+}
+
+// ── Supabase members table helpers ────────────────────────────────────────
+async function upsertMember(email, supabaseUrl, serviceKey) {
+  const res = await fetch(`${supabaseUrl}/rest/v1/members`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'resolution=merge-duplicates,return=minimal',
+    },
+    body: JSON.stringify([{ email }]),
+  });
+  if (!res.ok) throw new Error(`Supabase upsert failed: ${res.status}`);
+}
+
+async function deleteMember(email, supabaseUrl, serviceKey) {
+  const res = await fetch(`${supabaseUrl}/rest/v1/members?email=eq.${encodeURIComponent(email)}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!res.ok) throw new Error(`Supabase delete failed: ${res.status}`);
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
-    // Proxy Coach Tee requests to Anthropic
+    // ── Whop membership webhook ──────────────────────────────────────────
+    if (url.pathname === '/api/whop-webhook' && request.method === 'POST') {
+      const rawBody = await request.text();
+      const sigHeader = request.headers.get('Whop-Signature');
+
+      const valid = await verifyWhopSignature(env.WHOP_WEBHOOK_SECRET, rawBody, sigHeader);
+      if (!valid) return new Response('Unauthorized', { status: 401 });
+
+      let payload;
+      try { payload = JSON.parse(rawBody); } catch { return new Response('Bad JSON', { status: 400 }); }
+
+      const event = payload.event || payload.action;
+      // Whop nests user data under payload.data; email can sit directly or under data.user
+      const email = payload.data?.user?.email || payload.data?.email;
+
+      if (email) {
+        const sbUrl = env.SUPABASE_URL;
+        const sbKey = env.SUPABASE_SERVICE_ROLE_KEY;
+        try {
+          if (event === 'membership.went_valid') {
+            await upsertMember(email, sbUrl, sbKey);
+          } else if (event === 'membership.went_invalid') {
+            await deleteMember(email, sbUrl, sbKey);
+          }
+        } catch (e) {
+          console.error('Webhook DB error:', e);
+          return new Response('Internal error', { status: 500 });
+        }
+      }
+
+      return new Response('OK', { status: 200 });
+    }
+
+    // ── Coach Tee proxy ──────────────────────────────────────────────────
     if (url.pathname === '/api/coach-tee' && request.method === 'POST') {
       const { userMsg, systemPrompt } = await request.json();
 

--- a/supabase/functions/send-notifications/index.ts
+++ b/supabase/functions/send-notifications/index.ts
@@ -23,12 +23,69 @@ webpush.setVapidDetails(
     Deno.env.get('VAPID_PRIVATE_KEY')!
 );
 
+// ─── Notification copy ────────────────────────────────────────────────────
+// Indexed 0-6 (Sun–Sat) so messages rotate through the week without repeating.
+
+const TRAINING_REMINDERS = [
+    { title: 'Time to train.', body: '10-min warmup → protocol → done. Open The Blueprint.' },
+    { title: 'Your tissue is ready.', body: 'Nothing left but the work. Open the app and get it done.' },
+    { title: 'Consistency is the protocol.', body: 'One session today keeps the adaptation cycle running.' },
+    { title: 'Get the session in.', body: 'Warm up, execute, recover. That is the whole job.' },
+    { title: 'Progress is made tonight.', body: 'Collagen remodels 48–72 h after the stimulus. Give it one.' },
+    { title: 'Open The Blueprint.', body: 'Start the warmup. The rest follows.' },
+    { title: 'One session. That is it.', body: 'Warmup, work, done. Your future self does not skip.' },
+];
+
+const STREAK_REMINDERS = [
+    (streak: number) => ({ title: `Day ${streak + 1}. Keep it moving.`, body: 'Warm up, hit the protocol, log it. Streak stays alive.' }),
+    (streak: number) => ({ title: `${streak}-day streak on the line.`, body: 'One session keeps the chain unbroken. Open the app.' }),
+    (streak: number) => ({ title: `Day ${streak + 1}.`, body: 'Consistent reps compound. Do not let today be the gap.' }),
+    (streak: number) => ({ title: `${streak} days straight.`, body: 'Warmup → protocol → done. That is the whole move.' }),
+    (streak: number) => ({ title: `Streak alive: ${streak} days.`, body: 'Tissue adapts in recovery. Give it the stimulus first.' }),
+    (streak: number) => ({ title: `Day ${streak + 1}. You know the drill.`, body: '10 minutes of warmup and the work is half done.' }),
+    (streak: number) => ({ title: `${streak} days in.`, body: 'This is where most guys stop. You are not most guys.' }),
+];
+
+const RECOVERY_REMINDERS = [
+    { title: 'Recovery day.', body: 'Hip flexors + RK holds. 5 minutes locks in the gains.' },
+    { title: 'Active recovery today.', body: 'Pelvic floor release + box breathing. 5 min. Do it.' },
+    { title: 'Rest day protocol.', body: 'Reverse kegels + hip openers. Recovery work compounds.' },
+    { title: '5-min recovery session.', body: 'Stretch, breathe, release. Your tissue rebuilds tonight.' },
+    { title: 'Recovery is the work.', body: 'Drop into pelvic floor release + RK holds. 5 minutes.' },
+    { title: 'Open The Blueprint.', body: 'Recovery Protocol today — pelvic stretches + RK holds.' },
+    { title: 'Rest day. Do the work.', body: 'Hip openers + reverse kegels keep the floor supple.' },
+];
+
+function pickByDayOfWeek<T>(arr: T[], dayIndex: number): T {
+    return arr[dayIndex % arr.length];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function getUserLocalDayOfWeek(now: Date, timezone: string): number {
+    try {
+        const localStr = now.toLocaleDateString('en-US', { timeZone: timezone, weekday: 'short' });
+        const days: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+        return days[localStr.slice(0, 3)] ?? now.getUTCDay();
+    } catch {
+        return now.getUTCDay();
+    }
+}
+
+function getUserLocalDateISO(now: Date, timezone: string): string {
+    try {
+        // Build YYYY-MM-DD in user's local timezone
+        const parts = now.toLocaleDateString('en-CA', { timeZone: timezone }); // en-CA gives YYYY-MM-DD
+        return parts;
+    } catch {
+        return now.toISOString().split('T')[0];
+    }
+}
+
 Deno.serve(async () => {
     try {
         const now = new Date();
         const currentHour = now.getUTCHours();
-        const currentMinute = now.getUTCMinutes();
-        const todayISO = now.toISOString().split('T')[0];
 
         // Fetch all active push subscriptions
         const { data: subs, error } = await supabase
@@ -43,37 +100,46 @@ Deno.serve(async () => {
 
         for (const sub of subs) {
             try {
-                // Convert stored reminder time to UTC hour using timezone
+                const timezone = sub.timezone || 'UTC';
                 const reminderTime = sub.reminder_time || '19:00';
-                const [rh, rm] = reminderTime.split(':').map(Number);
+                const [rh] = reminderTime.split(':').map(Number);
 
-                // Get UTC offset for user's timezone
-                const userDate = new Date(now.toLocaleString('en-US', { timeZone: sub.timezone || 'UTC' }));
-                const utcDate = new Date(now.toLocaleString('en-US', { timeZone: 'UTC' }));
+                // Convert reminder local hour → UTC hour
+                const userDate = new Date(now.toLocaleString('en-US', { timeZone: timezone }));
+                const utcDate  = new Date(now.toLocaleString('en-US', { timeZone: 'UTC' }));
                 const offsetHours = Math.round((userDate.getTime() - utcDate.getTime()) / 3600000);
                 const reminderUTCHour = ((rh - offsetHours) + 24) % 24;
 
-                // Only send if current UTC hour matches the reminder hour (±window of 1 hour)
-                if (Math.abs(currentHour - reminderUTCHour) > 1) continue;
+                // Only fire in the exact matching UTC hour (cron is hourly — this fires once)
+                if (currentHour !== reminderUTCHour) continue;
 
-                // Fetch user's session log to check if they trained today
+                // Fetch user data
                 const { data: userData } = await supabase
                     .from('user_data')
-                    .select('session_log, total_xp')
+                    .select('session_log, schedule')
                     .eq('id', sub.user_id)
                     .single();
 
                 if (!userData) continue;
 
                 const sessionLog: Array<{ date: string }> = userData.session_log || [];
-                const trainedToday = sessionLog.some(s => s.date?.startsWith(todayISO));
+                const schedule: string[] = userData.schedule || [];
 
-                // Calculate current streak
+                // Use user's local date so "today" matches their clock, not UTC
+                const localToday = getUserLocalDateISO(now, timezone);
+                const trainedToday = sessionLog.some(s => s.date?.startsWith(localToday));
+
+                // Determine today's schedule type (0=Sun … 6=Sat in user's local time)
+                const localDayOfWeek = getUserLocalDayOfWeek(now, timezone);
+                const todayType: string = schedule[localDayOfWeek] || 'rest';
+                const isRestDay = todayType === 'rest';
+
+                // Calculate streak
                 let streak = 0;
                 const days = new Set(sessionLog.map((s: { date: string }) => s.date?.split('T')[0]));
                 for (let i = 0; i < 365; i++) {
                     const d = new Date(now);
-                    d.setDate(d.getDate() - i);
+                    d.setUTCDate(d.getUTCDate() - i);
                     const key = d.toISOString().split('T')[0];
                     if (days.has(key)) { streak++; }
                     else if (i > 0) { break; }
@@ -81,28 +147,32 @@ Deno.serve(async () => {
 
                 let notification = null;
 
-                // Streak warning — send at 20:00 local if they have a streak and haven't trained
+                // 1. Streak warning at a fixed 8 PM local if they haven't trained
                 if (sub.streak_warn && streak >= 3 && !trainedToday) {
                     const streakUTCHour = ((20 - offsetHours) + 24) % 24;
-                    if (Math.abs(currentHour - streakUTCHour) <= 1) {
+                    if (currentHour === streakUTCHour) {
                         notification = {
                             title: `🔥 Streak at risk — ${streak} days`,
-                            body: "You haven't trained today. Don't break the streak.",
+                            body: "You haven't trained today. Don't break the chain.",
                             tag: 'streak-warning',
                             renotify: true,
                         };
                     }
                 }
 
-                // Daily reminder — if not trained and matches reminder time
-                if (!notification && !trainedToday && Math.abs(currentHour - reminderUTCHour) <= 1) {
-                    notification = {
-                        title: 'The Blueprint — Time to train',
-                        body: streak > 0
-                            ? `Day ${streak + 1} streak. Open the app and get it done.`
-                            : "Your protocol is waiting. Open the app.",
-                        tag: 'daily-reminder',
-                    };
+                // 2. Daily reminder — send regardless of rest/training day;
+                //    skip only if they already completed any session today.
+                if (!notification && !trainedToday) {
+                    if (isRestDay) {
+                        const base = pickByDayOfWeek(RECOVERY_REMINDERS, localDayOfWeek);
+                        notification = { ...base, tag: 'daily-reminder' };
+                    } else if (streak > 0) {
+                        const fn = pickByDayOfWeek(STREAK_REMINDERS, localDayOfWeek);
+                        notification = { ...fn(streak), tag: 'daily-reminder' };
+                    } else {
+                        const base = pickByDayOfWeek(TRAINING_REMINDERS, localDayOfWeek);
+                        notification = { ...base, tag: 'daily-reminder' };
+                    }
                 }
 
                 if (!notification) continue;
@@ -113,7 +183,7 @@ Deno.serve(async () => {
                 );
                 sent++;
             } catch (subErr) {
-                // Subscription may be expired — clean it up
+                // Subscription expired — remove it
                 if ((subErr as { statusCode?: number }).statusCode === 410) {
                     await supabase.from('push_subscriptions').delete().eq('user_id', sub.user_id);
                 }


### PR DESCRIPTION
## What's in this PR

**Login & auth fixes**
- Login no longer stays stuck on the auth screen — a `_signingIn` lock prevents `handleAuthSubmit` and `onAuthStateChange` from running `onUserSignedIn` concurrently and fighting over the auth screen visibility
- Sign out button now works instantly — UI resets immediately without waiting on the network; any in-flight sign-in flow aborts cleanly
- Login spinner can no longer freeze forever — `signInWithPassword` now has a 20-second timeout via `Promise.race`

**Progress/data loss fix**
- Sessions logged on a flaky mobile connection were silently lost — the Supabase write failed but localStorage had the newer data; on next login Supabase's stale row overwrote it. Fixed by storing a `_savedAt` timestamp in localStorage and using whichever source is newer on load

**Timer screen lock**
- Screen timing out during a set paused the timer (RAF is suspended when screen locks). Added Screen Wake Lock API — screen stays on while any timer is running, released when idle

**Notifications**
- Fixed 3-hour firing window (was `±1 hour` tolerance, caused 3 notifications or wrong time). Now exact hour match
- Added local notification scheduler — fires at the set time directly from the browser via the service worker, no server required. Works immediately without any backend setup
- Rest days now send a recovery reminder (RK holds, pelvic floor release, hip openers) instead of silence
- 7 rotating messages per category so reminders don't repeat daily

**Whop member access**
- New webhook endpoint `POST /api/whop-webhook` — verifies Whop signature, grants access on `membership_activated`, revokes on `membership_deactivated`
- No more manual Supabase row inserts for every new buyer

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUGxuSdnA8sDzGELxbZAaS)_