### PR TITLE
Fix sign-in appearing stuck when data load hangs on slow connections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1914,8 +1914,14 @@ async function loadPersisted(){
     let localData=null;
     try{const raw=localStorage.getItem('bp_data_'+currentUser.id);if(raw)localData=JSON.parse(raw);}catch(e){}
     try{
-        const {data,error} = await sb.from('user_data').select('*').eq('id',currentUser.id).single();
-        if(error||!data){
+        const _timeout=new Promise((_,rej)=>setTimeout(()=>rej(new Error('timeout')),8000));
+        const _query=sb.from('user_data').select('*').eq('id',currentUser.id).single();
+        const {data,error}=await Promise.race([_query,_timeout]).catch(e=>{
+            // Timeout or network error — fall back to localStorage
+            if(localData) try{const {_savedAt:_,...rest}=localData;persisted={...DEFAULT_PERSISTED,...rest};}catch(e2){}
+            return {};
+        });
+        if(!data){
             if(localData) try{const {_savedAt:_,...rest}=localData;persisted={...DEFAULT_PERSISTED,...rest};}catch(e){}
             return;
         }


### PR DESCRIPTION
## What's in this PR

Single fix for the sign-in button appearing unresponsive.

### Root cause
After `signInWithPassword` succeeds, the button is re-enabled but then `onUserSignedIn` calls `loadPersisted()` which fetches user data from Supabase with **no timeout**. On a slow or stalled mobile connection this query hangs indefinitely — the auth screen stays visible and from the user's view nothing happened. They close and reopen, the session is already there, and the app opens automatically.

### Fix
Added an 8-second timeout on the `loadPersisted` Supabase query. On timeout it falls back to localStorage data (same path as a network error) so the app opens instead of freezing.

https://claude.ai/code/session_01YUGxuSdnA8sDzGELxbZAaS

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUGxuSdnA8sDzGELxbZAaS)_