### PR TITLE
Deploy send-notifications edge function

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,23 @@
+name: Deploy Supabase Edge Functions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/functions/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy send-notifications
+        run: supabase functions deploy send-notifications --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # node_modules/
 
+# Supabase CLI cache
+supabase/.temp/
+
 # wrangler files
 .wrangler
 .dev.vars*

--- a/index.html
+++ b/index.html
@@ -3915,7 +3915,7 @@ async function onUserSignedIn(user){
 // ═══════════════════════════════════════════════════════════════════════════
 // PUSH NOTIFICATIONS
 // ═══════════════════════════════════════════════════════════════════════════
-const VAPID_PUBLIC_KEY='BHNs21bsR6oKAN19h2o7tSH5s5QHEB3YCqrxaZ6WmMQ6zMJEeuPC7gZ0O7fUnf9qjFIEy19tLMoq2kT2v8q9jG8';
+const VAPID_PUBLIC_KEY='BNaN9NyzTiFTSmDKROx-7aTfT5rnIVVBcQDXGkzi5nrl5rt-VIqzdALnIIexqxaP-hZGxtUfhJ5IFMx_o8cz3-8';
 function _urlBase64ToUint8(b64){const p=(b64+'='.repeat((4-b64.length%4)%4)).replace(/-/g,'+').replace(/_/g,'/');const raw=atob(p);return Uint8Array.from([...raw].map(c=>c.charCodeAt(0)));}
 let _swRegistration=null;
 async function initServiceWorker(){


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to auto-deploy `send-notifications` edge function on push to main
- Updates VAPID public key in `index.html` to match the newly generated keypair set in Supabase secrets

## What this enables
The `send-notifications` edge function runs hourly via Supabase cron and sends push notifications to users based on their timezone, reminder time, and training schedule. The VAPID key update ensures the frontend can successfully subscribe users to push notifications.

## Before merging
Make sure these GitHub secrets are set (Settings → Secrets and variables → Actions):
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_PROJECT_ID` → `edqmujiczuvavlemfpaz`

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_