### PR TITLE
Fix iOS Safari crash and Whop webhook event names

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -53,6 +53,9 @@ export default {
     const url = new URL(request.url);
 
     // ── Whop membership webhook ──────────────────────────────────────────
+    if (url.pathname === '/api/whop-webhook' && request.method === 'GET') {
+      return new Response('OK', { status: 200 });
+    }
     if (url.pathname === '/api/whop-webhook' && request.method === 'POST') {
       const rawBody = await request.text();
       const sigHeader = request.headers.get('Whop-Signature');

--- a/src/worker.js
+++ b/src/worker.js
@@ -71,9 +71,9 @@ export default {
         const sbUrl = env.SUPABASE_URL;
         const sbKey = env.SUPABASE_SERVICE_ROLE_KEY;
         try {
-          if (event === 'membership.went_valid') {
+          if (event === 'membership.went_valid' || event === 'membership_activated') {
             await upsertMember(email, sbUrl, sbKey);
-          } else if (event === 'membership.went_invalid') {
+          } else if (event === 'membership.went_invalid' || event === 'membership_deactivated') {
             await deleteMember(email, sbUrl, sbKey);
           }
         } catch (e) {


### PR DESCRIPTION
## Summary
- Fixes iOS Safari crash: `Notification` API doesn't exist on iOS Safari, causing a `Can't find variable: Notification` error on sign-in. All four bare references now guard with `typeof Notification !== 'undefined'`
- Fixes Whop webhook event name mismatch: worker only handled `membership.went_valid` / `membership.went_invalid` but Whop fires `membership_activated` / `membership_deactivated`. Now handles both formats.

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_