### PR TITLE
Fix Whop webhook URL validation and iOS Safari crash

### DIFF
--- a/functions/api/whop-webhook.js
+++ b/functions/api/whop-webhook.js
@@ -75,3 +75,7 @@ export async function onRequestPost({ request, env }) {
 
   return new Response('OK', { status: 200 });
 }
+
+export async function onRequestGet() {
+  return new Response('OK', { status: 200 });
+}


### PR DESCRIPTION
## Summary
- Adds GET handler to the Pages Function webhook endpoint so Whop's URL validation ping gets a 200 instead of being rejected
- Also carries forward the iOS Safari Notification fix and webhook event name fixes from previous commits

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_