### PR TITLE
Re-enable webhook signature verification

### DIFF
--- a/functions/api/whop-webhook.js
+++ b/functions/api/whop-webhook.js
@@ -52,8 +52,7 @@ export async function onRequestPost({ request, env }) {
   const sigHeader = request.headers.get('Whop-Signature');
 
   const valid = await verifyWhopSignature(env.WHOP_WEBHOOK_SECRET, rawBody, sigHeader);
-  // TODO: re-enable once secret mismatch is resolved
-  // if (!valid) return new Response('Unauthorized', { status: 401 });
+  if (!valid) return new Response('Unauthorized', { status: 401 });
 
   let payload;
   try { payload = JSON.parse(rawBody); } catch { return new Response('Bad JSON', { status: 400 }); }

--- a/src/worker.js
+++ b/src/worker.js
@@ -61,8 +61,7 @@ export default {
       const sigHeader = request.headers.get('Whop-Signature');
 
       const valid = await verifyWhopSignature(env.WHOP_WEBHOOK_SECRET, rawBody, sigHeader);
-      // TODO: re-enable once secret mismatch is resolved
-      // if (!valid) return new Response('Unauthorized', { status: 401 });
+      if (!valid) return new Response('Unauthorized', { status: 401 });
 
       let payload;
       try { payload = JSON.parse(rawBody); } catch { return new Response('Bad JSON', { status: 400 }); }


### PR DESCRIPTION
## Summary
Re-enables Whop webhook signature verification now that the correct `WHOP_WEBHOOK_SECRET` is confirmed in Cloudflare. Endpoint is secured against unauthorized requests again.

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_