### PR TITLE
Fix webhook signature header parsing

### DIFF
--- a/functions/api/whop-webhook.js
+++ b/functions/api/whop-webhook.js
@@ -8,7 +8,9 @@
 
 async function verifyWhopSignature(secret, rawBody, signatureHeader) {
   if (!signatureHeader) return false;
-  const parts = Object.fromEntries(signatureHeader.split(',').map(p => p.split('=')));
+  const parts = Object.fromEntries(
+    signatureHeader.split(',').map(p => { const i = p.indexOf('='); return [p.slice(0,i).trim(), p.slice(i+1).trim()]; })
+  );
   const { t: timestamp, v0: receivedHex } = parts;
   if (!timestamp || !receivedHex) return false;
   if (Math.abs(Date.now() / 1000 - Number(timestamp)) > 300) return false; // reject replays > 5 min old

--- a/src/worker.js
+++ b/src/worker.js
@@ -4,7 +4,10 @@
 // Algorithm: HMAC-SHA256 with the webhook signing secret
 async function verifyWhopSignature(secret, rawBody, signatureHeader) {
   if (!signatureHeader) return false;
-  const parts = Object.fromEntries(signatureHeader.split(',').map(p => p.split('=')));
+  // Split on first '=' only to handle any values that might contain '='
+  const parts = Object.fromEntries(
+    signatureHeader.split(',').map(p => { const i = p.indexOf('='); return [p.slice(0,i).trim(), p.slice(i+1).trim()]; })
+  );
   const timestamp = parts.t;
   const receivedHex = parts.v0;
   if (!timestamp || !receivedHex) return false;


### PR DESCRIPTION
## Summary
Fixes webhook signature verification parsing. The old `split('=')` approach could silently fail if the header had leading whitespace after commas. Now splits on the first `=` only and trims each part.

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_