### PR TITLE
Reduce Lateral Compression to 15s with rest between sets

### DIFF
--- a/index.html
+++ b/index.html
@@ -1855,15 +1855,14 @@ const ROUTINES={
                 'Hold the squeeze gently for 10 to 20 seconds. Keep the pressure light — this is not a gripping exercise.',
                 'Release fully, breathe out slowly, and repeat for the set duration. Alternate with full releases between holds.',
             ],
-            sets:3, duration:60,
+            sets:3, duration:15,
             eq:'6-7 EQ (60-70%)',
             feel:'Deep internal pressure, lateral expansion at mid-shaft. Steady and controlled. No throbbing.',
             dontFeel:'Glans engorgement, head pressure, or any electric/tingling sensation. Release immediately.',
             cues:[
-                {time:60, text:'60-70% EQ. Thumb and two fingers at the coronal ridge — gentle squeeze only.'},
-                {time:45, text:'Hold 10-20 seconds, release, breathe out. No palm squeezing on mid-shaft.'},
-                {time:25, text:'Light coronal ridge pressure only. Hold steady and breathe.'},
-                {time:5,  text:'Release fully. Shake your hands out. Reset for the next set.'}
+                {time:15, text:'60-70% EQ. Thumb and two fingers at the coronal ridge — gentle squeeze.'},
+                {time:8,  text:'Hold light pressure. Breathe out slowly.'},
+                {time:3,  text:'Release fully. Rest coming up.'}
             ]
         }
     ]


### PR DESCRIPTION
## Summary
- Reduces Lateral Compression duration from 60s to 15s (within the 10-20s clinical guideline range)
- Updates in-session cues to match the 15s timer
- Rest overlay already fires automatically between sets (20s minimum), so users get a full active rest after every round

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_