### PR TITLE
Handle both body formats in Ko-fi webhook

### DIFF
--- a/functions/api/kofi-webhook.js
+++ b/functions/api/kofi-webhook.js
@@ -22,21 +22,23 @@ export async function onRequestPost({ request, env }) {
   let body;
   try {
     const text = await request.text();
-    console.log('Ko-fi raw body:', text.slice(0, 200));
+    console.log('Ko-fi raw body (200 chars):', text.slice(0, 200));
+
+    // Try URL-encoded first (Ko-fi's documented format), fall back to JSON
     const params = new URLSearchParams(text);
     const dataStr = params.get('data');
-    if (!dataStr) {
-      console.error('Ko-fi: no data field in body');
-      return new Response('Bad Request', { status: 400 });
+    if (dataStr) {
+      body = JSON.parse(dataStr);
+    } else {
+      // Some Ko-fi test requests send raw JSON
+      body = JSON.parse(text);
     }
-    body = JSON.parse(dataStr);
     console.log('Ko-fi parsed — type:', body.type, 'email:', body.email);
   } catch (e) {
-    console.error('Ko-fi parse error:', e);
-    return new Response('Bad JSON', { status: 400 });
+    console.error('Ko-fi parse error:', e.message);
+    return new Response('Bad Request', { status: 400 });
   }
 
-  // Verify token if configured
   if (env.KOFI_VERIFICATION_TOKEN && body.verification_token !== env.KOFI_VERIFICATION_TOKEN) {
     console.error('Ko-fi token mismatch');
     return new Response('Unauthorized', { status: 401 });
@@ -44,7 +46,7 @@ export async function onRequestPost({ request, env }) {
 
   const email = body.email;
   if (!email) {
-    console.error('Ko-fi: no email in payload');
+    console.error('Ko-fi: no email in payload — full body:', JSON.stringify(body));
     return new Response('OK', { status: 200 });
   }
 


### PR DESCRIPTION
Ko-fi's test button may send raw JSON instead of the documented `application/x-www-form-urlencoded` format. Now tries URL-encoded first, falls back to JSON. Also logs the full body when email is missing so we can see exactly what Ko-fi is sending.

https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw

---
_Generated by [Claude Code](https://claude.ai/code/session_015GpYcJhnGMbeKB4JXrqBMw)_